### PR TITLE
Fixes to Upstart job config

### DIFF
--- a/data/thermald.conf
+++ b/data/thermald.conf
@@ -12,6 +12,4 @@ stop on stopping dbus
 expect fork
 respawn
 
-script
-	exec thermald --no-daemon
-end script
+exec thermald --no-daemon

--- a/data/thermald.conf
+++ b/data/thermald.conf
@@ -9,7 +9,6 @@ start on (local-filesystems
 	)
 stop on stopping dbus
 
-expect fork
 respawn
 
 exec thermald --no-daemon

--- a/data/thermald.conf
+++ b/data/thermald.conf
@@ -11,4 +11,4 @@ stop on stopping dbus
 
 respawn
 
-exec thermald --no-daemon
+exec thermald --no-daemon --dbus-enable

--- a/data/thermald.conf
+++ b/data/thermald.conf
@@ -4,9 +4,7 @@
 
 description	"thermal daemon"
 
-start on (local-filesystems
-	  and started dbus
-	)
+start on started dbus
 stop on stopping dbus
 
 respawn


### PR DESCRIPTION
A couple of cosmetic fixes, and one important fix, to the Upstart job config.

The important fix is that “expect fork” is incorrect, and will cause buggy job tracking.