### PR TITLE
Load the preference value provided by the xml file

### DIFF
--- a/src/thd_engine.cpp
+++ b/src/thd_engine.cpp
@@ -209,6 +209,8 @@ int cthd_engine::thd_engine_start(bool ignore_cpuid_check) {
 		return THD_FATAL_ERROR;
 	}
 
+	parser.set_default_preference();
+
 	// Check if polling is disabled and sensors don't support
 	// async mode, in that enable force polling
 	if (!poll_interval_sec) {
@@ -276,6 +278,7 @@ int cthd_engine::thd_engine_start(bool ignore_cpuid_check) {
 		}
 	}
 #endif
+	thd_pref.refresh();
 	preference = thd_pref.get_preference();
 	thd_log_info("Current user preference is %d\n", preference);
 

--- a/src/thd_engine.cpp
+++ b/src/thd_engine.cpp
@@ -209,7 +209,9 @@ int cthd_engine::thd_engine_start(bool ignore_cpuid_check) {
 		return THD_FATAL_ERROR;
 	}
 
-	parser.set_default_preference();
+	if (parser.platform_matched()) {
+		parser.set_default_preference();
+	}
 
 	// Check if polling is disabled and sensors don't support
 	// async mode, in that enable force polling


### PR DESCRIPTION
The preference value was just parsed by phd_parser.cpp but not forwarded to the engine.
Hence, a call to the according parser function is necessary. Afterwards the preferences need to be refreshed.