### PR TITLE
Misc fixes for thermal daemon

### DIFF
--- a/src/android_main.cpp
+++ b/src/android_main.cpp
@@ -163,7 +163,6 @@ int main(int argc, char *argv[]) {
 	if (argc > 1) {
 		while ((c = getopt_long(argc, argv, short_options, long_options,
 				&option_index)) != -1) {
-			int this_option_optind = optind ? optind : 1;
 			switch (c) {
 			case 'h':
 				print_usage(stdout, 0);

--- a/src/android_main.cpp
+++ b/src/android_main.cpp
@@ -197,7 +197,7 @@ int main(int argc, char *argv[]) {
 		exit(EXIT_FAILURE);
 	}
 
-	if ((c = mkdir(TDRUNDIR, 0755)) != 0) {
+	if (mkdir(TDRUNDIR, 0755) != 0) {
 		if (errno != EEXIST) {
 			fprintf(stderr, "Cannot create '%s': %s\n", TDRUNDIR,
 					strerror(errno));

--- a/src/thd_dbus_interface.cpp
+++ b/src/thd_dbus_interface.cpp
@@ -285,7 +285,6 @@ gboolean thd_dbus_interface_add_virtual_sensor(PrefObject *obj, gchar *name,
 
 gboolean thd_dbus_interface_get_sensor_information(PrefObject *obj, gint index,
 		gchar **sensor_out, gchar **path, gint *temp, GError **error) {
-	char error_str[] = "Invalid Contents";
 	char *sensor_str;
 	char *path_str;
 
@@ -337,7 +336,6 @@ gboolean thd_dbus_interface_get_zone_count(PrefObject *obj, int *count,
 gboolean thd_dbus_interface_get_zone_information(PrefObject *obj, gint index,
 		gchar **zone_out, gint *sensor_count, gint *trip_count,
 		GError **error) {
-	char error_str[] = "Invalid Contents";
 	char *zone_str;
 
 	thd_log_debug("thd_dbus_interface_get_zone_information %d\n", index);
@@ -363,7 +361,6 @@ gboolean thd_dbus_interface_get_zone_information(PrefObject *obj, gint index,
 gboolean thd_dbus_interface_get_zone_sensor_at_index(PrefObject *obj,
 		gint zone_index, gint sensor_index, gchar **sensor_out,
 		GError **error) {
-	char error_str[] = "Invalid Contents";
 	char *sensor_str;
 
 	thd_log_debug("thd_dbus_interface_get_zone_sensor_at_index %d\n",
@@ -392,8 +389,6 @@ gboolean thd_dbus_interface_get_zone_sensor_at_index(PrefObject *obj,
 gboolean thd_dbus_interface_get_zone_trip_at_index(PrefObject *obj,
 		gint zone_index, gint trip_index, int *temp, int *trip_type,
 		int *sensor_id, int *cdev_size, GArray **cdev_ids, GError **error) {
-	char error_str[] = "Invalid Contents";
-
 	thd_log_debug("thd_dbus_interface_get_zone_sensor_at_index %d\n",
 			zone_index);
 
@@ -437,7 +432,6 @@ gboolean thd_dbus_interface_get_cdev_count(PrefObject *obj, int *count,
 gboolean thd_dbus_interface_get_cdev_information(PrefObject *obj, gint index,
 		gchar **cdev_out, gint *min_state, gint *max_state, gint *curr_state,
 		GError **error) {
-	char error_str[] = "Invalid Contents";
 	char *cdev_str;
 
 	thd_log_debug("thd_dbus_interface_get_cdev_information %d\n", index);
@@ -543,8 +537,6 @@ gboolean thd_dbus_interface_add_cooling_device(PrefObject *obj,
 gboolean thd_dbus_interface_update_cooling_device(PrefObject *obj,
 		gchar *cdev_name, gchar *path, gint min_state, gint max_state,
 		gint step, GError **error) {
-	int ret;
-
 	g_assert(obj != NULL);
 
 	return thd_dbus_interface_add_cooling_device(obj, cdev_name, path,

--- a/src/thd_engine.cpp
+++ b/src/thd_engine.cpp
@@ -1025,8 +1025,6 @@ int cthd_engine::user_get_zone_status(std::string name, int *status) {
 }
 
 int cthd_engine::user_delete_zone(std::string name) {
-	cthd_zone *zone;
-
 	pthread_mutex_lock(&thd_engine_mutex);
 	for (unsigned int i = 0; i < zones.size(); ++i) {
 		if (zones[i]->get_zone_type() == name) {

--- a/src/thd_engine.cpp
+++ b/src/thd_engine.cpp
@@ -657,7 +657,7 @@ void cthd_engine::thd_read_default_thermal_sensors() {
 	if (sensors.size())
 		current_sensor_index = max_index + 1;
 
-	thd_log_info("thd_read_default_thermal_sensors loaded %lu sensors \n",
+	thd_log_info("thd_read_default_thermal_sensors loaded %zu sensors \n",
 			sensors.size());
 }
 
@@ -691,7 +691,7 @@ void cthd_engine::thd_read_default_thermal_zones() {
 	}
 	if (zones.size())
 		current_zone_index = max_index + 1;
-	thd_log_info("thd_read_default_thermal_zones loaded %lu zones \n",
+	thd_log_info("thd_read_default_thermal_zones loaded %zu zones \n",
 			zones.size());
 }
 
@@ -725,7 +725,7 @@ void cthd_engine::thd_read_default_cooling_devices() {
 	if (cdevs.size())
 		current_cdev_index = max_index + 1;
 
-	thd_log_info("thd_read_default_cooling devices loaded %lu cdevs \n",
+	thd_log_info("thd_read_default_cooling devices loaded %zu cdevs \n",
 			cdevs.size());
 }
 

--- a/src/thd_trip_point.h
+++ b/src/thd_trip_point.h
@@ -162,7 +162,7 @@ public:
 				index, _type_str.c_str(), temp, hyst, zone_id, sensor_id,
 				(unsigned long) cdevs.size());
 		for (unsigned int i = 0; i < cdevs.size(); ++i) {
-			thd_log_info("cdev[%i] %s\n", i,
+			thd_log_info("cdev[%u] %s\n", i,
 					cdevs[i].cdev->get_cdev_type().c_str());
 		}
 	}


### PR DESCRIPTION
Hi there,

I just ran the latest version of thermal daemon through cppcheck and it found some minor issues that I've attended to with these fixes.

One more thing, the current release number of thermal_daemon is 1.41,  my concern is that at some point the release number will be bumped to 1.5 which is actually smaller than 1.41 in debian packaging terms, so it makes versioning the package tricky (since 5 is less than 41).   Is there a rationale behind the current versioning scheme? I was expecting a 1.4.3 version since the previous tags were 1.4.1, 1.4.2.  

Regards, Colin   