### PR TITLE
Minor spelling fixes in docs, README and one typo in command line options

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -176,7 +176,7 @@ Version 0.3
 - Added P states t states turbo states as the cooling methods
 - No longer depend on any thermal sysfs, zone cooling device by default
 - Uses DTS core temperature and p/turbo/t states to cool system
-- By default only will use DTS core temerature and p/turbo/t states only
+- By default only will use DTS core temperature and p/turbo/t states only
 - All the previous controls based on the zones/cdevs and XML configuration is only done, when activated via command line
 - The set points are calculated and stored in a config file when it hits thermal threshold and adjusted based
 on slope and angular increments to dynamically adjust set point

--- a/data/thermald.conf
+++ b/data/thermald.conf
@@ -7,10 +7,16 @@ description	"thermal daemon"
 start on runlevel [2345] and started dbus
 stop on stopping dbus
 
+#
+# don't respawn on error
+#
+normal exit 1
+
 respawn
 
-script
-echo "Waiting for thermal zone and coretemp sysfs to be ready "
-sleep 5
+#
+# consider something wrong if respawned 10 times in 1 minute
+#
+respawn limit 10 60
+
 exec thermald --no-daemon --dbus-enable
-end script

--- a/man/thermald.8
+++ b/man/thermald.8
@@ -36,7 +36,6 @@ temperature and applies compensation using available cooling methods.
 
 By default, it monitors CPU temperature using available CPU digital temperature sensors and maintains CPU temperature under control, before HW takes aggressive correction action.
 
-.TP
 Thermal daemon looks for thermal sensors and thermal cooling drivers in the Linux thermal sysfs (/sys/class/thermal) and builds a
 list of sensors and cooling drivers. Each of the thermal sensors can optionally be binded to a cooling drivers by the in kernel
 drivers. In this case the Linux kernel thermal core can directly take actions based on the temperature trip points, for each sensor
@@ -51,8 +50,6 @@ When there is a sensor, which has no associate cooling device, via configuration
 this sensor is tested for relationship with CPU load dynamically up to maximum 3 times. If there is no relationship, then
 it is added to a black list of unbinded sensors and not tried again.
 
-
-.TP
 Optionally thermal daemon can act as an exclusive thermal controller by using thermal sysfs and acting as a user space governor.
 In this case kernel thermal core is not active and decision is taken by thermal daemon only.
 

--- a/man/thermald.8
+++ b/man/thermald.8
@@ -48,7 +48,7 @@ file is automatically created and used, if the platform has ACPI thermal relatio
 manually configured.
 
 When there is a sensor, which has no associate cooling device, via configuration file or thermal relationship table, then
-this sensor is tested for relationship with CPU load dynamically upto maximum 3 times. If there is no relationship, then
+this sensor is tested for relationship with CPU load dynamically up to maximum 3 times. If there is no relationship, then
 it is added to a black list of unbinded sensors and not tried again.
 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -170,7 +170,7 @@ int main(int argc, char *argv[]) {
 					"Enable Dbus."), NULL }, { "exclusive-control", 0, 0,
 			G_OPTION_ARG_NONE, &exclusive_control, N_(
 					"Take over thermal control from kernel thermal driver."),
-			NULL }, { "ingore-cpuid-check", 0, 0, G_OPTION_ARG_NONE,
+			NULL }, { "ignore-cpuid-check", 0, 0, G_OPTION_ARG_NONE,
 			&ignore_cpuid_check, N_("Ignore CPU ID check."), NULL },
 
 	{ NULL } };


### PR DESCRIPTION
A few small fixes to documentation plus a typo fix in the the command line option --ignore-cpuid-check

And two fixes we've been carrying in Ubuntu for a release cycle so it's timely I asked for these to be pulled into thermald since they need to be upstreamed after a lot of use.