### PR TITLE
tools/thermal_monitor: Repair header includes

### DIFF
--- a/tools/thermal_monitor/mainwindow.h
+++ b/tools/thermal_monitor/mainwindow.h
@@ -17,6 +17,9 @@
 
 #include <QMainWindow>
 #include <QVector>
+#include <QLabel>
+#include <QMessageBox>
+#include <QDesktopWidget>
 #include <string>
 #include <QVBoxLayout>
 #include "qcustomplot/qcustomplot.h"


### PR DESCRIPTION
Building on a clean system produces compiler errors for the thermal_monitor.
Adding the relevant headers in resolves the issue and compiles cleanly.

Errors Produced:

mainwindow.h:72:5: error: ‘QLabel’ does not name a type
     QLabel *sensor_label;
     ^
mainwindow.h:73:5: error: ‘QLabel’ does not name a type
     QLabel *sensor_temp;
     ^
main.cpp: In function ‘int main(int, char**)’:
main.cpp:28:9: error: ‘QMessageBox’ was not declared in this scope
         QMessageBox msgBox;
         ^
main.cpp:34:9: error: ‘msgBox’ was not declared in this scope
         msgBox.setText(str);
         ^
main.cpp:35:35: error: ‘QMessageBox’ is not a class or namespace
         msgBox.setStandardButtons(QMessageBox::Abort);
                                   ^
main.cpp:39:14: error: ‘QMessageBox’ is not a class or namespace
         case QMessageBox::Abort:
              ^
Makefile:280: recipe for target 'main.o' failed

Signed-off-by: Kieran Bingham <kieranbingham@gmail.com>