### PR TITLE
cpufreq: one bug fix and one minor variable name spell fix

### DIFF
--- a/src/thd_cdev_cpufreq.cpp
+++ b/src/thd_cdev_cpufreq.cpp
@@ -89,8 +89,8 @@ int cthd_cdev_cpufreq::init() {
 	// Check scaling max frequency and min frequency
 	// Remove frequencies above and below this in the freq list
 	// The available list contains these frequencies even if they are not allowed
-	unsigned int scaling_min_frqeuency = 0;
-	unsigned int scaling_max_frqeuency = 0;
+	unsigned int scaling_min_frequency = 0;
+	unsigned int scaling_max_frequency = 0;
 	for (int i = cpu_start_index; i <= cpu_end_index; ++i) {
 		std::stringstream str;
 		std::string freq_str;
@@ -99,8 +99,8 @@ int cthd_cdev_cpufreq::init() {
 			cdev_sysfs.read(str.str(), freq_str);
 			unsigned int freq_int;
 			std::istringstream(freq_str) >> freq_int;
-			if (scaling_min_frqeuency == 0 || freq_int < scaling_min_frqeuency)
-				scaling_min_frqeuency = freq_int;
+			if (scaling_min_frequency == 0 || freq_int < scaling_min_frequency)
+				scaling_min_frequency = freq_int;
 		}
 	}
 
@@ -113,13 +113,13 @@ int cthd_cdev_cpufreq::init() {
 
 			unsigned int freq_int;
 			std::istringstream(freq_str) >> freq_int;
-			if (scaling_max_frqeuency == 0 || freq_int > scaling_max_frqeuency)
-				scaling_max_frqeuency = freq_int;
+			if (scaling_max_frequency == 0 || freq_int > scaling_max_frequency)
+				scaling_max_frequency = freq_int;
 		}
 	}
 
-	thd_log_debug("cpu freq max %u min %u\n", scaling_max_frqeuency,
-			scaling_min_frqeuency);
+	thd_log_debug("cpu freq max %u min %u\n", scaling_max_frequency,
+			scaling_min_frequency);
 
 	for (unsigned int i = 0; i < _cpufreqs.size(); ++i) {
 		thd_log_debug("cpu freq Add %d: %s\n", i, _cpufreqs[i].c_str());
@@ -127,8 +127,8 @@ int cthd_cdev_cpufreq::init() {
 		unsigned int freq_int;
 		std::istringstream(_cpufreqs[i]) >> freq_int;
 
-		if (freq_int >= scaling_min_frqeuency
-				&& freq_int <= scaling_max_frqeuency) {
+		if (freq_int >= scaling_min_frequency
+				&& freq_int <= scaling_max_frequency) {
 			cpufreqs.push_back(freq_int);
 		}
 	}

--- a/src/thd_cdev_cpufreq.cpp
+++ b/src/thd_cdev_cpufreq.cpp
@@ -178,7 +178,7 @@ void cthd_cdev_cpufreq::set_curr_state(int state, int arg) {
 }
 
 int cthd_cdev_cpufreq::get_max_state() {
-	return cpufreqs.size();
+	return cpufreqs.size() - 1;
 }
 
 int cthd_cdev_cpufreq::update() {


### PR DESCRIPTION
Hi,

Thank you for thermald, this is very useful!

The "off by one" fix fixes a bad behavior of the thermald in my case. On my Athlon 64 X2 I have the following CPU frequencies available to cpufreq:

cpu freq 0: 2300000
cpu freq 1: 2200000
cpu freq 2: 2000000
cpu freq 3: 1800000
cpu freq 4: 1000000

With the off-by-one bug, thermald would go to state 1 (2.2 GHz), 3 (1.8 GHz) and then increase erroneously to state 5 (non-existing off-by-one). This request for state 5 will get silently ignored at the cpufreq cdev and the CPU will stay at 1.8 GHz.

Fixing the off-by-one bug makes thermald request state 4 instead of state 5, which gets serviced correctly and the CPU goes all the way down to 1 GHz as it should.

The other fix is just some substitution of a misspelled variable name. Both fixes should be independent.

Best regards,

V.