### PR TITLE
thermald: thd_cdev_modem: only return THD_SUCCESS if a value is fetched

### DIFF
--- a/src/thd_cdev_modem.cpp
+++ b/src/thd_cdev_modem.cpp
@@ -145,6 +145,7 @@ int cthd_cdev_modem::get_modem_property(DBusConnection* conn,
 	DBusMessage *reply;
 	DBusMessageIter array;
 	DBusMessageIter dict;
+	int rc = THD_ERROR;
 
 	dbus_error_init(&error);
 
@@ -156,7 +157,7 @@ int cthd_cdev_modem::get_modem_property(DBusConnection* conn,
 		thd_log_error("Error creating D-Bus message for GetProperties "
 				"under %s : %s\n", modem_path.c_str(),
 				error.message);
-		return THD_ERROR;
+		return rc;
 	}
 
 	reply = dbus_connection_send_with_reply_and_block(conn, msg, 10000,
@@ -166,7 +167,7 @@ int cthd_cdev_modem::get_modem_property(DBusConnection* conn,
 				modem_path.c_str(), error.message);
 		dbus_error_free(&error);
 		dbus_message_unref(msg);
-		return THD_ERROR;
+		return rc;
 	}
 
 	dbus_message_unref(msg);
@@ -176,7 +177,7 @@ int cthd_cdev_modem::get_modem_property(DBusConnection* conn,
 		thd_log_error("GetProperties return type not array under %s!\n",
 				modem_path.c_str());
 		dbus_message_unref(reply);
-		return THD_ERROR;
+		return rc;
 	}
 
 	dbus_message_iter_recurse(&array, &dict);
@@ -194,7 +195,7 @@ int cthd_cdev_modem::get_modem_property(DBusConnection* conn,
 			thd_log_error("GetProperties dict key type not string "
 					"under %s!\n", modem_path.c_str());
 			dbus_message_unref(reply);
-			return THD_ERROR;
+			return rc;
 		}
 
 		dbus_message_iter_get_basic(&key, &property_name);
@@ -214,7 +215,7 @@ int cthd_cdev_modem::get_modem_property(DBusConnection* conn,
 					"variant under %s!\n",
 					modem_path.c_str());
 			dbus_message_unref(reply);
-			return THD_ERROR;
+			return rc;
 		}
 
 		dbus_message_iter_recurse(&key, &var);
@@ -225,16 +226,17 @@ int cthd_cdev_modem::get_modem_property(DBusConnection* conn,
 					"boolean under %s!\n",
 					modem_path.c_str());
 			dbus_message_unref(reply);
-			return THD_ERROR;
+			return rc;
 		}
 
 		dbus_message_iter_get_basic(&var, value);
+		rc = THD_SUCCESS;
 		break;
 	}
 
 	dbus_message_unref(reply);
 
-	return THD_SUCCESS;
+	return rc;
 }
 
 int cthd_cdev_modem::update_online_state(DBusConnection* conn) {

--- a/src/thd_msr.cpp
+++ b/src/thd_msr.cpp
@@ -265,10 +265,13 @@ int cthd_msr::set_clock_mod_duty_cycle(int state) {
 
 	for (int i = 0; i < cpu_count; ++i) {
 		ret = read_msr(i, MSR_IA32_THERM_CONTROL, &val);
+		if (ret < 0) {
+			thd_log_debug("set_clock_mod_duty_cycle current MSR read failed\n");
+			return THD_ERROR;
+		}
+
 		thd_log_debug("set_clock_mod_duty_cycle current %x\n",
 				(unsigned int) val);
-		if (ret < 0)
-			return THD_ERROR;
 
 		if (!state) {
 			val &= ~MSR_IA32_CLK_MOD_ENABLE;
@@ -298,9 +301,12 @@ int cthd_msr::get_clock_mod_duty_cycle() {
 
 	// Just get for cpu 0 and return
 	ret = read_msr(0, MSR_IA32_THERM_CONTROL, &val);
-	thd_log_debug("get_clock_mod_duty_cycle current %x\n", (unsigned int) val);
-	if (ret < 0)
+	if (ret < 0) {
+		thd_log_debug("get_clock_mod_duty_cycle current MSR read failed\n");
 		return THD_ERROR;
+	}
+
+	thd_log_debug("get_clock_mod_duty_cycle current %x\n", (unsigned int) val);
 
 	if (val & MSR_IA32_CLK_MOD_ENABLE) {
 		state = val & MSR_IA32_CLK_MOD_DUTY_CYCLE_MASK;
@@ -372,9 +378,12 @@ int cthd_msr::dec_freq_state_per_cpu(int cpu) {
 	int current_clock;
 
 	ret = read_msr(cpu, MSR_IA32_PERF_CTL, &val);
-	thd_log_debug("perf_ctl current %x\n", (unsigned int) val);
-	if (ret < 0)
+	if (ret < 0) {
+		thd_log_debug("perf_ctl current read MSR failed\n");
 		return THD_ERROR;
+	}
+
+	thd_log_debug("perf_ctl current %x\n", (unsigned int) val);
 
 	current_clock = (val >> 8) & 0xff;
 	current_clock--;
@@ -405,9 +414,12 @@ int cthd_msr::dec_freq_state() {
 
 	for (int i = 0; i < cpu_count; ++i) {
 		ret = read_msr(i, MSR_IA32_PERF_CTL, &val);
-		thd_log_debug("perf_ctl current %x\n", (unsigned int) val);
-		if (ret < 0)
+		if (ret < 0) {
+			thd_log_debug("perf_ctl current MSR read failed\n");
 			return THD_ERROR;
+		}
+
+		thd_log_debug("perf_ctl current %x\n", (unsigned int) val);
 
 		current_clock = (val >> 8) & 0xff;
 		current_clock--;


### PR DESCRIPTION
get_modem_property currently returns THD_SUCCESS when a value is sometimes
not fetched.  This fix ensures THD_SUCCESS is only returned when value is
correctly fetched.  Bug found with scan-build static analysis:

src/thd_cdev_modem.cpp:245:10: warning: Assigned value is garbage or undefined
                online = online_state;
                       ^ ~~~~~~~~~~~~
src/thd_cdev_modem.cpp:258:14: warning: Assigned value is garbage or undefined
                throttling = enabled;
                           ^ ~~~~~~~

Signed-off-by: Colin Ian King <colin.king@canonical.com>