### PR TITLE
check for recv failure and ensure buffer is null terminated

### DIFF
--- a/src/thd_kobj_uevent.cpp
+++ b/src/thd_kobj_uevent.cpp
@@ -50,13 +50,16 @@ void cthd_kobj_uevent::kobj_uevent_close() {
 }
 
 bool cthd_kobj_uevent::check_for_event() {
-	int i = 0;
-	int len;
+	ssize_t i = 0;
+	ssize_t len;
 	const char *dev_path = "DEVPATH=";
 	unsigned int dev_path_len = strlen(dev_path);
 	char buffer[max_buffer_size];
 
-	len = recv(fd, buffer, sizeof(buffer), MSG_DONTWAIT);
+	len = recv(fd, buffer, sizeof(buffer) - 1, MSG_DONTWAIT);
+	if (len <= 0)
+		return false;
+	buffer[len] = '\0';
 
 	while (i < len) {
 		if (strlen(buffer + i) > dev_path_len


### PR DESCRIPTION
The recv read buffer may fill completely, leaving the buffer not
null terminated which is a hazard with string handling this buffer.
Check that the recv has enough data to null terminate the buffer
and also add a fast path return if the buffer is too short null
terminate.

Signed-off-by: Colin Ian King <colin.king@canonical.com>