### PR TITLE
thd_cdev: ensure _target_value is initialized

### DIFF
--- a/src/thd_cdev.cpp
+++ b/src/thd_cdev.cpp
@@ -199,7 +199,7 @@ int cthd_cdev::thd_cdev_set_state(int set_point, int target_temp,
 			}
 		}
 	} else {
-		thd_log_debug("zone_trip_limits.size() %lu\n", zone_trip_limits.size());
+		thd_log_debug("zone_trip_limits.size() %zu\n", (size_t)zone_trip_limits.size());
 		if (zone_trip_limits.size() > 0) {
 			int length = zone_trip_limits.size();
 			int _target_value = TRIP_PT_INVALID_TARGET_STATE;

--- a/src/thd_cdev.cpp
+++ b/src/thd_cdev.cpp
@@ -202,7 +202,7 @@ int cthd_cdev::thd_cdev_set_state(int set_point, int target_temp,
 		thd_log_debug("zone_trip_limits.size() %lu\n", zone_trip_limits.size());
 		if (zone_trip_limits.size() > 0) {
 			int length = zone_trip_limits.size();
-			int _target_value;
+			int _target_value = TRIP_PT_INVALID_TARGET_STATE;
 			int i;
 
 			// Just remove the current zone requesting to turn off


### PR DESCRIPTION
This fixes an issue discovered by static analysis with
CoverityScan.

CoverityScan CID#157084 ("Uninitialized scalar value")

Signed-off-by: Colin Ian King <colin.king@canonical.com>