### PR TITLE
Android build fixes

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -2,51 +2,44 @@ LOCAL_PATH:= $(call my-dir)
 
 include $(CLEAR_VARS)
 
-thermald_src_path := ./src
-thermald_src_files := \
-		$(thermald_src_path)/android_main.cpp \
-		$(thermald_src_path)/thd_engine.cpp \
-		$(thermald_src_path)/thd_cdev.cpp \
-		$(thermald_src_path)/thd_cdev_therm_sys_fs.cpp \
-		$(thermald_src_path)/thd_engine_default.cpp \
-		$(thermald_src_path)/thd_sys_fs.cpp \
-		$(thermald_src_path)/thd_trip_point.cpp \
-		$(thermald_src_path)/thd_zone.cpp \
-		$(thermald_src_path)/thd_zone_surface.cpp \
-		$(thermald_src_path)/thd_zone_cpu.cpp \
-		$(thermald_src_path)/thd_zone_therm_sys_fs.cpp \
-		$(thermald_src_path)/thd_preference.cpp \
-		$(thermald_src_path)/thd_model.cpp \
-		$(thermald_src_path)/thd_parse.cpp \
-		$(thermald_src_path)/thd_sensor.cpp \
-		$(thermald_src_path)/thd_sensor_virtual.cpp \
-		$(thermald_src_path)/thd_kobj_uevent.cpp \
-		$(thermald_src_path)/thd_cdev_order_parser.cpp \
-		$(thermald_src_path)/thd_cdev_gen_sysfs.cpp \
-		$(thermald_src_path)/thd_pid.cpp \
-		$(thermald_src_path)/thd_zone_generic.cpp \
-		$(thermald_src_path)/thd_cdev_cpufreq.cpp \
-		$(thermald_src_path)/thd_cdev_rapl.cpp \
-		$(thermald_src_path)/thd_cdev_intel_pstate_driver.cpp \
-		$(thermald_src_path)/thd_msr.cpp \
-		$(thermald_src_path)/thd_rapl_interface.cpp \
-		$(thermald_src_path)/thd_cdev_msr_rapl.cpp \
-		$(thermald_src_path)/thd_rapl_power_meter.cpp \
-		$(thermald_src_path)/thd_trt_art_reader.cpp \
-		$(thermald_src_path)/thd_cdev_rapl_dram.cpp \
-		$(thermald_src_path)/thd_cpu_default_binding.cpp \
-		$(thermald_src_path)/thd_cdev_backlight.cpp
+LOCAL_SRC_FILES := \
+		src/android_main.cpp \
+		src/thd_engine.cpp \
+		src/thd_cdev.cpp \
+		src/thd_cdev_therm_sys_fs.cpp \
+		src/thd_engine_default.cpp \
+		src/thd_sys_fs.cpp \
+		src/thd_trip_point.cpp \
+		src/thd_zone.cpp \
+		src/thd_zone_surface.cpp \
+		src/thd_zone_cpu.cpp \
+		src/thd_zone_therm_sys_fs.cpp \
+		src/thd_zone_dynamic.cpp \
+		src/thd_preference.cpp \
+		src/thd_model.cpp \
+		src/thd_parse.cpp \
+		src/thd_sensor.cpp \
+		src/thd_sensor_virtual.cpp \
+		src/thd_kobj_uevent.cpp \
+		src/thd_cdev_order_parser.cpp \
+		src/thd_cdev_gen_sysfs.cpp \
+		src/thd_pid.cpp \
+		src/thd_zone_generic.cpp \
+		src/thd_cdev_cpufreq.cpp \
+		src/thd_cdev_rapl.cpp \
+		src/thd_cdev_intel_pstate_driver.cpp \
+		src/thd_rapl_power_meter.cpp \
+		src/thd_trt_art_reader.cpp \
+		src/thd_cdev_rapl_dram.cpp \
+		src/thd_cpu_default_binding.cpp \
+		src/thd_cdev_backlight.cpp
 
-LOCAL_C_INCLUDES += $(LOCAL_PATH) $(thermald_src_path) \
-			external/icu4c/common \
-			external/libxml2/include \
-			system/core/include/
+LOCAL_C_INCLUDES += external/libxml2/include
 
 LOCAL_MODULE_TAGS := optional
-LOCAL_CFLAGS := -DTDRUNDIR='"/data/thermal-daemon"' -DTDCONFDIR='"/system/etc/thermal-daemon"'
+LOCAL_CFLAGS := -DTDRUNDIR='"/data/thermal-daemon"' -DTDCONFDIR='"/system/etc/thermal-daemon"' -Wno-unused-parameter
 LOCAL_STATIC_LIBRARIES := libxml2
 LOCAL_SHARED_LIBRARIES := liblog libcutils libdl libc++ libicuuc libicui18n libbinder libutils
 LOCAL_PRELINK_MODULE := false
-LOCAL_SRC_FILES := $(thermald_src_files)
 LOCAL_MODULE := thermal-daemon
 include $(BUILD_EXECUTABLE)

--- a/src/thd_engine_default.cpp
+++ b/src/thd_engine_default.cpp
@@ -36,7 +36,10 @@
 #include "thd_cdev_rapl_dram.h"
 #include "thd_sensor_virtual.h"
 #include "thd_cdev_backlight.h"
+
+#ifdef GLIB_SUPPORT
 #include "thd_cdev_modem.h"
+#endif
 
 // Default CPU cooling devices, which are not part of thermal sysfs
 // Since non trivial initialization is not supported, we init all fields even if they are not needed
@@ -502,7 +505,8 @@ int cthd_engine_default::add_replace_cdev(cooling_dev_t *config) {
 	}
 	if (!cdev_present) {
 		// create new
-		if (config->type_string.compare("intel_modem") == 0)
+		if (config->type_string.compare("intel_modem") == 0) {
+#ifdef GLIB_SUPPORT
 			/*
 			 * Add Modem as cdev
 			 * intel_modem is a modem identifier across all intel platforms.
@@ -510,7 +514,8 @@ int cthd_engine_default::add_replace_cdev(cooling_dev_t *config) {
 			 * are to be taken care in the cdev implementation.
 			 */
 			cdev = new cthd_cdev_modem(current_cdev_index, config->path_str);
-		else
+#endif
+		} else
 			cdev = new cthd_gen_sysfs_cdev(current_cdev_index, config->path_str);
 		if (!cdev)
 			return THD_ERROR;

--- a/src/thd_trip_point.h
+++ b/src/thd_trip_point.h
@@ -129,14 +129,14 @@ public:
 		return cdevs.size();
 	}
 
+#ifndef ANDROID
 	trip_pt_cdev_t &get_cdev_at_index(unsigned int index) {
 		if (index < cdevs.size())
 			return cdevs[index];
-#ifndef ANDROID
 		else
 			throw std::invalid_argument("index");
-#endif
 	}
+#endif
 
 	void trip_cdev_add(trip_pt_cdev_t trip_cdev) {
 		int index;


### PR DESCRIPTION
Right now it seems to be impossible to compile thermal_daemon for Android:

- The build file is missing several source files. I've removed the existing list and copied the new list directly from `Makefile.am` (except for `thd_dbus_interface.cpp` and `thd_cdev_modem.cpp` because that requires DBUS which is not available on Android)

- There are a few compile errors because the DBUS code is not always properly guarded by checking if `GLIB_SUPPORT` is defined. I've added checks where necessary.

- There was a missing `return` statement in a method where an exception was disabled because Android disables them by default. That method seems to be only used from DBUS code so I've just disabled it entirely for Android.

Compiles successfully in Android N tree.